### PR TITLE
Fix #1: compile error re PaperOptions.model

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^2.4.0",
     "@angular/platform-browser-dynamic": "^2.4.0",
     "@angular/router": "^3.4.0",
+    "@types/backbone": "^1.3.36",
     "@types/jquery": "^2.0.40",
     "core-js": "^2.4.1",
     "jointjs": "https://github.com/clientIO/joint",


### PR DESCRIPTION
Adding the backbone types with

```
npm install --save @types/backbone
```

solves the problem.